### PR TITLE
chore(deps): bump fast-uri to 3.1.2

### DIFF
--- a/backend-exercise/pnpm-lock.yaml
+++ b/backend-exercise/pnpm-lock.yaml
@@ -1427,8 +1427,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -3729,14 +3729,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4188,7 +4188,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fb-watchman@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Resolves two high-severity advisories in `fast-uri` (transitive via `@nestjs/cli > @angular-devkit/core > ajv`):
  - GHSA-q3j6-qgpj-74h6 — path traversal via percent-encoded dot segments
  - GHSA-v39h-62p7-jpjc — host confusion via percent-encoded authority delimiters
- Lockfile-only bump: `ajv`'s existing `fast-uri: ^3.0.1` range already permits 3.1.2, so no `package.json` change is needed.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm audit` reports no known vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)